### PR TITLE
Employ RpcSendTransactionConfig::default() for better forward compatibility

### DIFF
--- a/common/src/client/rpc.rs
+++ b/common/src/client/rpc.rs
@@ -183,7 +183,7 @@ pub fn send_txn(client: &RpcClient, txn: &Transaction, _simulate: bool) -> Resul
         CommitmentConfig::single(),
         RpcSendTransactionConfig {
             skip_preflight: true,
-            preflight_commitment: None,
+            ..RpcSendTransactionConfig::default()
         },
     )?)
 }

--- a/common/tests/src/lib.rs
+++ b/common/tests/src/lib.rs
@@ -138,7 +138,7 @@ pub fn client_at<T: ClientGen>(program_id: Pubkey) -> T {
             commitment: CommitmentConfig::single(),
             tx: RpcSendTransactionConfig {
                 skip_preflight: true,
-                preflight_commitment: None,
+                ..RpcSendTransactionConfig::default()
             },
         })
 }

--- a/crank/src/lib.rs
+++ b/crank/src/lib.rs
@@ -666,7 +666,7 @@ fn consume_events_once(
         &txn,
         RpcSendTransactionConfig {
             skip_preflight: true,
-            preflight_commitment: None,
+            ..RpcSendTransactionConfig::default()
         },
     )?;
     Ok(signature)

--- a/node/context/src/lib.rs
+++ b/node/context/src/lib.rs
@@ -40,7 +40,7 @@ impl Context {
                 commitment: CommitmentConfig::single(),
                 tx: RpcSendTransactionConfig {
                     skip_preflight: true,
-                    preflight_commitment: None,
+                    ..RpcSendTransactionConfig::default()
                 },
             },
         );

--- a/solana-client-gen/codegen/src/lib.rs
+++ b/solana-client-gen/codegen/src/lib.rs
@@ -145,7 +145,7 @@ pub fn solana_client_gen(
                         commitment: CommitmentConfig::single(),
                         tx: RpcSendTransactionConfig {
                             skip_preflight: true,
-                            preflight_commitment: None,
+                            ..RpcSendTransactionConfig::default()
                         },
                     },
                 };


### PR DESCRIPTION
The `RpcSendTransactionConfig` struct is the Rust representation of  [sendTransaction](https://docs.solana.com/apps/jsonrpc-api#sendtransaction)'s JSON configuration object.  New fields may be added to this struct in the future as we add more configuration parameters.    

This PR causes the default value for new fields to be accepted without a compile error on upgrade, which follows the same semantics as the JSON object it represents.

cc: 3dc834b1debb2a2498c9aabb411209755a16c51a