### PR TITLE
travis: Cargo build worksace in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,5 +45,6 @@ jobs:
     - <<: *defaults
       name: Fmt and Common Tests
       script:
+        - docker exec dev cargo build
         - docker exec dev cargo fmt -- --check
         - docker exec -w=/workdir/common dev cargo test --features client,strict


### PR DESCRIPTION
Building the entire workspace in CI to catch build failures that show up in downstream CIs, but not our own, e.g. the build failure fixed by https://github.com/project-serum/serum-dex/pull/49.