### PR TITLE
Use renamed serum-borsh package

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 solana-sdk = { version = "1.3.14", default-features = false }
 
 # Forks.
-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
+serum-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
 
 # Program only.
 solana-program = { version = "1.4.3", optional = true }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,8 +6,8 @@ repository = "https://github.com/project-serum/serum-dex"
 edition = "2018"
 
 [features]
-program = ["borsh/serum-program", "spl-token/program", "solana-sdk/program", "solana-program"]
-client = ["borsh/serum-client", "spl-token/default", "solana-sdk/default", "solana-client", "anyhow", "rand", "serde_json", "bs58", "bincode"]
+program = ["serum-borsh/serum-program", "spl-token/program", "solana-sdk/program", "solana-program"]
+client = ["serum-borsh/serum-client", "spl-token/default", "solana-sdk/default", "solana-client", "anyhow", "rand", "serde_json", "bs58", "bincode"]
 strict = []
 devnet = []
 default = []

--- a/lockup/Cargo.toml
+++ b/lockup/Cargo.toml
@@ -6,8 +6,8 @@ repository = "https://github.com/project-serum/serum-dex"
 edition = "2018"
 
 [features]
-program = ["borsh/serum-program", "solana-client-gen/program", "spl-token/program", "serum-common/program"]
-client = ["borsh/serum-client", "solana-client-gen/client", "spl-token/default", "serum-common/client", "lazy_static"]
+program = ["serum-borsh/serum-program", "solana-client-gen/program", "spl-token/program", "serum-common/program"]
+client = ["serum-borsh/serum-client", "solana-client-gen/client", "spl-token/default", "serum-common/client", "lazy_static"]
 test = []
 strict = []
 default = []

--- a/lockup/Cargo.toml
+++ b/lockup/Cargo.toml
@@ -22,7 +22,7 @@ bytemuck = "1.4.0"
 arrayref = "0.3.6"
 
 # Forks.
-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
+serum-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
 
 # Client only.
 lazy_static = { version = "1.4.0", optional = true }

--- a/pool/Cargo.toml
+++ b/pool/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = "1.0.20"
 zerocopy = "0.3.0"
 bytemuck = "1.4.1"
 slice-of-array = "0.2.1"
-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
+serum-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
 anyhow = { version = "1.0.33", default-features = false }
 hex = "0.4.2"
 base64 = "0.13.0"

--- a/pool/examples/admin-controlled/Cargo.toml
+++ b/pool/examples/admin-controlled/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 solana-program = "1.4.14"
 serum-pool = { version = "0.1.0", path = "../.." }
 spl-token = { version = "3.0.0", features = ["no-entrypoint"] }
-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
+serum-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
 
 [lib]
 name = "serum_pool_examples_admin_controlled"

--- a/pool/schema/Cargo.toml
+++ b/pool/schema/Cargo.toml
@@ -9,7 +9,7 @@ program = []
 default = []
 
 [dependencies]
-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
+serum-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
 solana-program = "1.4.14"
 
 [[bin]]

--- a/registry/Cargo.toml
+++ b/registry/Cargo.toml
@@ -20,7 +20,7 @@ solana-client-gen = { path = "../solana-client-gen" }
 serum-common = { path = "../common" }
 
 # Forks.
-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
+serum-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
 
 # Client only.
 lazy_static = { version = "1.4.0", optional = true }

--- a/registry/client/Cargo.toml
+++ b/registry/client/Cargo.toml
@@ -11,7 +11,7 @@ thiserror = "1.0.20"
 lazy_static = { version = "1.4.0" }
 solana-client = { version = "1.3.14" }
 spl-token = { version = "2.0.6", default-features = false }
-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
+serum-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
 serum-registry = { path = "../", features = ["client"] }
 solana-client-gen = { path = "../../solana-client-gen" }
 serum-common = { path = "../../common" }

--- a/registry/meta-entity/Cargo.toml
+++ b/registry/meta-entity/Cargo.toml
@@ -22,7 +22,7 @@ solana-client-gen = { path = "../../solana-client-gen" }
 serum-common = { path = "../../common" }
 
 # Forks.
-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
+serum-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
 
 # Client only.
 lazy_static = { version = "1.4.0", optional = true }

--- a/registry/meta-entity/Cargo.toml
+++ b/registry/meta-entity/Cargo.toml
@@ -6,8 +6,8 @@ repository = "https://github.com/project-serum/serum-dex"
 edition = "2018"
 
 [features]
-program = ["borsh/serum-program", "solana-client-gen/program", "spl-token/program", "serum-common/program"]
-client = ["borsh/serum-client", "solana-client-gen/client", "spl-token/default", "serum-common/client", "lazy_static"]
+program = ["serum-borsh/serum-program", "solana-client-gen/program", "spl-token/program", "serum-common/program"]
+client = ["serum-borsh/serum-client", "solana-client-gen/client", "spl-token/default", "serum-common/client", "lazy_static"]
 test = []
 strict = []
 default = []

--- a/registry/program/Cargo.toml
+++ b/registry/program/Cargo.toml
@@ -24,7 +24,7 @@ serum-common = { path = "../../common", features = ["program"] }
 serum-lockup = { path = "../../lockup", features = ["program"] }
 solana-program = "1.4.3"
 arrayref = "0.3.6"
-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
+serum-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
 
 [profile.release]
 lto = true

--- a/registry/rewards/Cargo.toml
+++ b/registry/rewards/Cargo.toml
@@ -22,7 +22,7 @@ solana-client-gen = { path = "../../solana-client-gen" }
 serum-common = { path = "../../common" }
 
 # Forks.
-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
+serum-borsh = { git = "https://github.com/project-serum/borsh", branch = "serum" }
 
 # Client only.
 lazy_static = { version = "1.4.0", optional = true }


### PR DESCRIPTION
Our borsh fork was recently renamed so that it could be published to crates.io. These changes update to use the new name.