### PR TITLE
Dex V3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ _localnet: &localnet
     - npm install -g @solana/web3.js
     - sudo apt-get install -y pkg-config build-essential libudev-dev
     - sh -c "$(curl -sSfL https://release.solana.com/v1.5.5/install)"
-    - solana-test-validator
+    - export PATH="/home/travis/.local/share/solana/install/active_release/bin:$PATH"
+    - solana-test-validator > validator.log &
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ jobs:
       name: Dex integration tests
       <<: *localnet
       script:
-        - docker exec dev solana-test-validator > validator.log &
         - docker exec dev ./scripts/travis/dex-tests.sh
     - <<: *defaults
       name: Fmt and Common Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: shell
 os: linux
 
@@ -18,7 +19,7 @@ _localnet: &localnet
     - 14
   before_script:
     - npm install -g @solana/web3.js
-    - sudo apt-get install -y pkg-config build-essential libudev-dev libssl-dev
+    - sudo apt-get install -y pkg-config build-essential libudev-dev
     - sh -c "$(curl -sSfL https://release.solana.com/v1.5.5/install)"
     - solana-test-validator
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ _localnet: &localnet
   node_js:
     - 14
   before_script:
-    - npm install -g @solana/web3.js
     - sudo apt-get install -y pkg-config build-essential libudev-dev
     - sh -c "$(curl -sSfL https://release.solana.com/v1.5.5/install)"
     - export PATH="/home/travis/.local/share/solana/install/active_release/bin:$PATH"
-    - solana-test-validator > validator.log &
+    - yes | solana-keygen new
+    - sudo solana-test-validator > validator.log &
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ _localnet: &localnet
     - sudo apt-get install -y pkg-config build-essential libudev-dev
     - sh -c "$(curl -sSfL https://release.solana.com/v1.5.5/install)"
     - export PATH="/home/travis/.local/share/solana/install/active_release/bin:$PATH"
-    - yes | solana-keygen new
-    - sudo solana-test-validator > validator.log &
 
 jobs:
   include:
@@ -34,6 +32,7 @@ jobs:
       name: Dex integration tests
       <<: *localnet
       script:
+        - docker exec dev solana-test-validator > validator.log &
         - docker exec dev ./scripts/travis/dex-tests.sh
     - <<: *defaults
       name: Fmt and Common Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ _localnet: &localnet
     - 14
   before_script:
     - npm install -g @solana/web3.js
-    - sudo apt-get install -y pkg-config build-essential libudev-dev
+    - sudo apt-get install -y pkg-config build-essential libudev-dev libssl-dev
     - sh -c "$(curl -sSfL https://release.solana.com/v1.5.5/install)"
     - solana-test-validator
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ _localnet: &localnet
     - 14
   before_script:
     - npm install -g @solana/web3.js
-    - npx solana-localnet update
-    - npx solana-localnet up
+    - sh -c "$(curl -sSfL https://release.solana.com/v1.5.5/install)"
+    - solana-test-validator
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ _localnet: &localnet
     - 14
   before_script:
     - npm install -g @solana/web3.js
+    - sudo apt-get install -y pkg-config build-essential libudev-dev
     - sh -c "$(curl -sSfL https://release.solana.com/v1.5.5/install)"
     - solana-test-validator
 

--- a/dex/Cargo.lock
+++ b/dex/Cargo.lock
@@ -90,23 +90,11 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.3",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -132,12 +120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
-
-[[package]]
 name = "bytemuck"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,13 +138,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
 name = "curve25519-dalek"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.8.1",
  "rand_core",
  "subtle",
  "zeroize",
@@ -200,6 +194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "either"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "atty",
  "humantime",
@@ -237,12 +240,6 @@ dependencies = [
  "regex",
  "termcolor",
 ]
-
-[[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "feature-probe"
@@ -292,7 +289,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi",
 ]
@@ -324,12 +321,9 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "itertools"
@@ -364,7 +358,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -374,13 +368,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
-name = "memmap"
-version = "0.7.0"
+name = "memmap2"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+checksum = "d9b70ca2a6103ac8b665dc150b142ef0e4e89df640c9e6cf295d189c3caebe5a"
 dependencies = [
  "libc",
- "winapi",
 ]
 
 [[package]]
@@ -448,9 +441,9 @@ checksum = "4eae0151b9dacf24fcc170d9995e511669a082856a91f958a2fe380bfab3fb22"
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "ppv-lite86"
@@ -735,27 +728,28 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.8.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
+checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
 dependencies = [
  "block-buffer",
- "digest",
- "fake-simd",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.4.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b1c4f649f305d1cb1454bd5de691872bc2631b99746341b5af8b4d561dbf06"
+checksum = "0d0c1cf7dafbcf4e1e0a56b7b28848bdf41a5e3065e9763d3aae892027109956"
 dependencies = [
  "bs58",
  "bv",
  "generic-array 0.14.4",
  "log",
- "memmap",
+ "memmap2",
  "rustc_version",
  "serde",
  "serde_derive",
@@ -767,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.4.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c84e6316d0b71d60ff34d2cc1a25521f6cb605111590a61e9baa768ac1234d4"
+checksum = "cb44325468e78e9e4535c90c656c36c953b42cd34ed4999d39f1d33b8780a545"
 dependencies = [
  "lazy_static",
  "proc-macro2 1.0.19",
@@ -780,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.4.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e6d1862202b2f6aba9bd346ef10cdecb29e05948d25ad3a3789f4239000012"
+checksum = "b7a46715d2f6fda4697f640038fbd2a16645b10af81dbf2e5a19048c99b8a546"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -791,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.4.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cf8a198b1443fccc12fab0e4927d1a3add3e5e9bd249bb61191c04d47e3c09"
+checksum = "fb200f05cb93b01f6e9b2e0d94d240e7e5dfa0b14c4308713b236c01a525a0ef"
 dependencies = [
  "bincode",
  "bs58",
@@ -821,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.4.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8da0dcb182f9631a69b4d6de69f82f0aa8bf2350c666122b9fad99380547ccc"
+checksum = "d463f2a24e75ca02f065ac2a9ac855f661c8d0f8917090514d65e4f82cdf05ab"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.19",
@@ -886,7 +880,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand",
  "redox_syscall",

--- a/dex/Cargo.toml
+++ b/dex/Cargo.toml
@@ -16,7 +16,7 @@ default = ["program"]
 no-entrypoint = []
 
 [dependencies]
-solana-program = "1.4.4"
+solana-program = "1.5.5"
 spl-token = { version = "3.0.0-pre1", features = ["no-entrypoint"] }
 serde = "1.0.114"
 itertools = "0.9.0"

--- a/dex/README.md
+++ b/dex/README.md
@@ -19,7 +19,7 @@ Using the `do.sh` script from the repository's top level directory,
 ### Deploy the dex to the configured solana cluster
 
 ```bash
-DEX_PROGRAM_ID="$(solana deploy dex/target/bpfel-unknown-unknown/release/serum_dex.so --use-deprecated-loader | jq .programId -r)"
+DEX_PROGRAM_ID="$(solana deploy dex/target/bpfel-unknown-unknown/release/serum_dex.so | jq .programId -r)"
 ```
 
 ## Run the fuzz tests
@@ -82,7 +82,7 @@ NDEBUG=1 ./run.sh
 solana config set -u http://127.0.0.1:8899
 solana-keygen new
 solana airdrop 100
-DEX_PROGRAM_ID="$(solana deploy dex/target/bpfel-unknown-unknown/release/serum_dex.so --use-deprecated-loader | jq .programId -r)"
+DEX_PROGRAM_ID="$(solana deploy dex/target/bpfel-unknown-unknown/release/serum_dex.so | jq .programId -r)"
 CLUSTER=localnet
 KEYPAIR=~/.config/solana/id.json
 

--- a/dex/fuzz/Cargo.lock
+++ b/dex/fuzz/Cargo.lock
@@ -592,7 +592,6 @@ dependencies = [
  "static_assertions",
  "thiserror",
  "without-alloc",
- "zerocopy",
 ]
 
 [[package]]
@@ -748,18 +747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,27 +855,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e34736feff52a0b3e5680927e947a4d8fac1f0b80dc8120b080dd8de24d75e2"
 dependencies = [
  "alloc-traits",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6580539ad917b7c026220c4b3f2c08d52ce54d6ce0dc491e66002e35388fab46"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d498dbd1fd7beb83c86709ae1c33ca50942889473473d287d56ce4770a18edfb"
-dependencies = [
- "proc-macro2",
- "syn",
- "synstructure",
 ]
 
 [[package]]

--- a/dex/proptest-regressions/instruction.txt
+++ b/dex/proptest-regressions/instruction.txt
@@ -10,3 +10,4 @@ cc a4118a6d7c82c191d95704129985f0761b3c6b82a056485e88ea549e6145608a # shrinks to
 cc f8cb82aea20fce7b1585efea458f5a8d08c967df78da4720197145e6fa587f80 # shrinks to inst = CancelOrder(CancelOrderInstruction { side: Bid, order_id: 0, owner: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], owner_slot: 0 })
 cc 9b33e7cb4c2b4e3a34b7b6fdeb7feb49cee9196047870cff53dac8b9483e9245 # shrinks to inst = NewOrder(NewOrderInstruction { side: Bid, limit_price: 1, max_qty: 1, order_type: Limit, client_id: 0 })
 cc 2a279ee739ee4b89416a838543703ace70b994031ac37da2f863025d828bfca6 # shrinks to inst = NewOrder(NewOrderInstruction { side: Bid, limit_price: 1, max_qty: 1, order_type: Limit, client_id: 0 })
+cc 4cd7226dfe9ac17741d91c4a3d8fbd22116654b0ea54c82f2357882404c281b4 # shrinks to inst = CancelOrderByClientIdV2(0)

--- a/dex/src/critbit.rs
+++ b/dex/src/critbit.rs
@@ -27,6 +27,7 @@ enum NodeTag {
 
 #[derive(Copy, Clone)]
 #[repr(packed)]
+#[allow(dead_code)]
 struct InnerNode {
     tag: u32,
     prefix_len: u32,
@@ -125,6 +126,7 @@ impl LeafNode {
 
 #[derive(Copy, Clone)]
 #[repr(packed)]
+#[allow(dead_code)]
 struct FreeNode {
     tag: u32,
     next: u32,
@@ -158,9 +160,10 @@ const_assert_eq!(_NODE_ALIGN, _FREE_NODE_ALIGN);
 
 #[derive(Copy, Clone)]
 #[repr(packed)]
+#[allow(dead_code)]
 pub struct AnyNode {
     tag: u32,
-    padding: [u32; 17],
+    data: [u32; 17],
 }
 unsafe impl Zeroable for AnyNode {}
 unsafe impl Pod for AnyNode {}

--- a/dex/src/error.rs
+++ b/dex/src/error.rs
@@ -106,6 +106,10 @@ pub enum DexErrorCode {
     WrongRentSysvarAccount,
     RentNotProvided,
     OrdersNotRentExempt,
+    OrderNotFound,
+    OrderNotYours,
+
+    WouldSelfTrade,
 
     Unknown = 1000,
 

--- a/dex/src/lib.rs
+++ b/dex/src/lib.rs
@@ -15,12 +15,12 @@ pub mod state;
 
 #[cfg(feature = "program")]
 use solana_program::{
-    account_info::AccountInfo, entrypoint::ProgramResult, entrypoint_deprecated, pubkey::Pubkey,
+    account_info::AccountInfo, entrypoint::ProgramResult, entrypoint, pubkey::Pubkey,
 };
 
 #[cfg(feature = "program")]
 #[cfg(not(feature = "no-entrypoint"))]
-entrypoint_deprecated!(process_instruction);
+entrypoint!(process_instruction);
 #[cfg(feature = "program")]
 fn process_instruction(
     program_id: &Pubkey,

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 ARG SOLANA_CHANNEL=v1.2.17
-ARG SOLANA_CLI=v1.3.9
+ARG SOLANA_CLI=v1.5.5
 
 ENV HOME="/root"
 ENV PATH="${HOME}/.cargo/bin:${PATH}"

--- a/registry/rewards/Makefile
+++ b/registry/rewards/Makefile
@@ -16,7 +16,7 @@ deploy-registry:
 	$(eval TEST_REGISTRY_PROGRAM_ID=$(shell echo $(TMP) | sed 's/.*{programId: \(.*\)}.*/\1/g'))
 
 deploy-dex:
-	$(eval TEST_DEX_PROGRAM_ID=$(shell solana deploy $(SOL_OPTIONS) ../../dex/target/bpfel-unknown-unknown/release/serum_dex.so --use-deprecated-loader | jq .programId -r))
+	$(eval TEST_DEX_PROGRAM_ID=$(shell solana deploy $(SOL_OPTIONS) ../../dex/target/bpfel-unknown-unknown/release/serum_dex.so | jq .programId -r))
 
 test-program:
 	make TEST_PROGRAM_ID=$(TEST_PROGRAM_ID) TEST_DEX_PROGRAM_ID=$(TEST_DEX_PROGRAM_ID) TEST_REGISTRY_PROGRAM_ID=$(TEST_REGISTRY_PROGRAM_ID) test-program-super

--- a/scripts/travis/dex-tests.sh
+++ b/scripts/travis/dex-tests.sh
@@ -12,6 +12,14 @@ CLUSTER_URL=http://localhost:8899
 main() {
     set +e
     #
+    # Start the local validator.
+    #
+    solana-test-validator > validator.log &
+    #
+    # Wait for the validator to start.
+    #
+    sleep 5
+    #
     # Create a keypair for the tests.
     #
     yes | solana-keygen new --outfile $KEYPAIR_FILE

--- a/scripts/travis/dex-tests.sh
+++ b/scripts/travis/dex-tests.sh
@@ -10,10 +10,10 @@ CLUSTER_URL=http://localhost:8899
 # Assumes the current working directory is top-level serum-dex dir.
 #
 main() {
+    set +e
     #
     # Create a keypair for the tests.
     #
-    set +e
     yes | solana-keygen new --outfile $KEYPAIR_FILE
     #
     # Fund the keypair.

--- a/scripts/travis/dex-tests.sh
+++ b/scripts/travis/dex-tests.sh
@@ -34,7 +34,7 @@ dex_whole_shebang() {
     #
     # Deploy the program.
     #
-    local dex_program_id="$(solana deploy --url ${CLUSTER_URL} dex/target/bpfel-unknown-unknown/release/serum_dex.so --use-deprecated-loader | jq .programId -r)"
+    local dex_program_id="$(solana deploy --url ${CLUSTER_URL} dex/target/bpfel-unknown-unknown/release/serum_dex.so | jq .programId -r)"
     #
     # Run the whole-shebang.
     #

--- a/scripts/travis/dex-tests.sh
+++ b/scripts/travis/dex-tests.sh
@@ -34,7 +34,7 @@ dex_whole_shebang() {
     #
     # Deploy the program.
     #
-    local dex_program_id="$(solana deploy --url ${CLUSTER_URL} dex/target/bpfel-unknown-unknown/release/serum_dex.so | jq .programId -r)"
+    local dex_program_id="$(solana deploy --url ${CLUSTER_URL} dex/target/bpfel-unknown-unknown/release/serum_dex.so | jq .ProgramId -r)"
     #
     # Run the whole-shebang.
     #

--- a/scripts/travis/run-docker.sh
+++ b/scripts/travis/run-docker.sh
@@ -16,7 +16,7 @@ main() {
     #
     # Start the container.
     #
-    docker run -it -d --name dev \
+    docker run -it -d --net host --name dev \
            -v workdir:/workdir \
            projectserum/development:latest bash
 }

--- a/scripts/travis/run-docker.sh
+++ b/scripts/travis/run-docker.sh
@@ -16,7 +16,7 @@ main() {
     #
     # Start the container.
     #
-    docker run -it -d --net host --name dev \
+    docker run -it -d --name dev \
            -v workdir:/workdir \
            projectserum/development:latest bash
 }


### PR DESCRIPTION
The next incremental update of the dex. The primary change is to immediately match incoming orders against the book, instead of first buffering them in the request queue. The request queue still exists to reduce breakage, but is always empty. Because of this, we're forced to remove support for the old order placement and cancellation instructions, since they don't provide the bids and asks accounts which would be necessary in order to process them in the new model.