### PR TITLE
Fix writable spl token program account which should be readonly

### DIFF
--- a/dex/src/instruction.rs
+++ b/dex/src/instruction.rs
@@ -556,7 +556,7 @@ pub fn settle_funds(
         AccountMeta::new(*coin_wallet, false),
         AccountMeta::new(*pc_wallet, false),
         AccountMeta::new_readonly(*vault_signer, false),
-        AccountMeta::new(*spl_token_program_id, false),
+        AccountMeta::new_readonly(*spl_token_program_id, false),
     ];
     if let Some(key) = referrer_pc_wallet {
         accounts.push(AccountMeta::new(*key, false))


### PR DESCRIPTION
This is a minor bugfix for a previous PR of mine. While the `SettleFunds` instruction requires the account for `spl_token_program`, it of course doesn't require the account to be writable.

This is a pretty important bug to fix since having the `spl_token_program` account as writable requires a lock on an account which is in heavy use.