### PR TITLE
Mark Various Functions, And Enums Public For On-Chain Price Calculations

### DIFF
--- a/dex/src/critbit.rs
+++ b/dex/src/critbit.rs
@@ -255,7 +255,7 @@ pub struct SlabHeader {
     pub bump_index: u64,
     pub free_list_len: u64,
     pub free_list_head: u32,
- 
+
     pub root_node: u32,
     pub leaf_count: u64,
 }

--- a/dex/src/critbit.rs
+++ b/dex/src/critbit.rs
@@ -168,12 +168,12 @@ pub struct AnyNode {
 unsafe impl Zeroable for AnyNode {}
 unsafe impl Pod for AnyNode {}
 
-enum NodeRef<'a> {
+pub enum NodeRef<'a> {
     Inner(&'a InnerNode),
     Leaf(&'a LeafNode),
 }
 
-enum NodeRefMut<'a> {
+pub enum NodeRefMut<'a> {
     Inner(&'a mut InnerNode),
     Leaf(&'a mut LeafNode),
 }

--- a/dex/src/critbit.rs
+++ b/dex/src/critbit.rs
@@ -201,7 +201,7 @@ impl AnyNode {
         }
     }
 
-    fn case(&self) -> Option<NodeRef> {
+    pub fn case(&self) -> Option<NodeRef> {
         match NodeTag::try_from(self.tag) {
             Ok(NodeTag::InnerNode) => Some(NodeRef::Inner(cast_ref(self))),
             Ok(NodeTag::LeafNode) => Some(NodeRef::Leaf(cast_ref(self))),
@@ -511,7 +511,7 @@ impl Slab {
                 }
                 _ => return Some(root),
             }
-        }
+        } 
     }
 
     #[inline]

--- a/dex/src/critbit.rs
+++ b/dex/src/critbit.rs
@@ -91,7 +91,7 @@ impl LeafNode {
     #[inline]
     pub fn price(&self) -> NonZeroU64 {
         NonZeroU64::new((self.key >> 64) as u64).unwrap()
-    } 
+    }
 
     #[inline]
     pub fn order_id(&self) -> u128 {
@@ -139,7 +139,6 @@ const fn _const_max(a: usize, b: usize) -> usize {
     let gt = (a > b) as usize;
     gt * a + (1 - gt) * b
 }
- 
 const _INNER_NODE_SIZE: usize = size_of::<InnerNode>();
 const _LEAF_NODE_SIZE: usize = size_of::<LeafNode>();
 const _FREE_NODE_SIZE: usize = size_of::<FreeNode>();
@@ -511,7 +510,7 @@ impl Slab {
                 }
                 _ => return Some(root),
             }
-        } 
+        }
     }
 
     #[inline]

--- a/dex/src/critbit.rs
+++ b/dex/src/critbit.rs
@@ -251,13 +251,13 @@ const_assert_eq!(_NODE_ALIGN, align_of::<AnyNode>());
 
 #[derive(Copy, Clone)]
 #[repr(packed)]
-struct SlabHeader {
-    bump_index: u64,
-    free_list_len: u64,
-    free_list_head: u32,
-
-    root_node: u32,
-    leaf_count: u64,
+pub struct SlabHeader {
+    pub bump_index: u64,
+    pub free_list_len: u64,
+    pub free_list_head: u32,
+ 
+    pub root_node: u32,
+    pub leaf_count: u64,
 }
 unsafe impl Zeroable for SlabHeader {}
 unsafe impl Pod for SlabHeader {}
@@ -346,19 +346,19 @@ impl Slab {
         (header, nodes)
     }
 
-    fn header(&self) -> &SlabHeader {
+    pub fn header(&self) -> &SlabHeader {
         self.parts().0
     }
 
-    fn header_mut(&mut self) -> &mut SlabHeader {
+    pub fn header_mut(&mut self) -> &mut SlabHeader {
         self.parts_mut().0
     }
 
-    fn nodes(&self) -> &[AnyNode] {
+    pub fn nodes(&self) -> &[AnyNode] {
         self.parts().1
     }
 
-    fn nodes_mut(&mut self) -> &mut [AnyNode] {
+    pub fn nodes_mut(&mut self) -> &mut [AnyNode] {
         self.parts_mut().1
     }
 }

--- a/dex/src/critbit.rs
+++ b/dex/src/critbit.rs
@@ -91,7 +91,7 @@ impl LeafNode {
     #[inline]
     pub fn price(&self) -> NonZeroU64 {
         NonZeroU64::new((self.key >> 64) as u64).unwrap()
-    }
+    } 
 
     #[inline]
     pub fn order_id(&self) -> u128 {
@@ -492,7 +492,7 @@ pub enum SlabTreeError {
 }
 
 impl Slab {
-    fn root(&self) -> Option<NodeHandle> {
+    pub fn root(&self) -> Option<NodeHandle> {
         if self.header().leaf_count == 0 {
             return None;
         }

--- a/dex/src/critbit.rs
+++ b/dex/src/critbit.rs
@@ -29,11 +29,11 @@ enum NodeTag {
 #[repr(packed)]
 #[allow(dead_code)]
 pub struct InnerNode {
-    tag: u32,
-    prefix_len: u32,
-    key: u128,
-    children: [u32; 2],
-    _padding: [u64; 5],
+    pub tag: u32,
+    pub prefix_len: u32,
+    pub key: u128,
+    pub children: [u32; 2],
+    pub _padding: [u64; 5],
 }
 unsafe impl Zeroable for InnerNode {}
 unsafe impl Pod for InnerNode {}
@@ -139,7 +139,7 @@ const fn _const_max(a: usize, b: usize) -> usize {
     let gt = (a > b) as usize;
     gt * a + (1 - gt) * b
 }
-
+ 
 const _INNER_NODE_SIZE: usize = size_of::<InnerNode>();
 const _LEAF_NODE_SIZE: usize = size_of::<LeafNode>();
 const _FREE_NODE_SIZE: usize = size_of::<FreeNode>();

--- a/dex/src/critbit.rs
+++ b/dex/src/critbit.rs
@@ -28,7 +28,7 @@ enum NodeTag {
 #[derive(Copy, Clone)]
 #[repr(packed)]
 #[allow(dead_code)]
-struct InnerNode {
+pub struct InnerNode {
     tag: u32,
     prefix_len: u32,
     key: u128,

--- a/dex/src/matching.rs
+++ b/dex/src/matching.rs
@@ -143,7 +143,7 @@ impl<'ob> OrderBookState<'ob> {
     }
 }
 
-pub(crate) struct RequestProceeds {
+pub struct RequestProceeds {
     pub coin_unlocked: u64,
     pub native_pc_unlocked: u64,
 
@@ -182,7 +182,7 @@ impl RequestProceeds {
     impl_incr_method!(debit_native_pc, native_pc_debit);
 }
 
-pub(crate) struct NewOrderParams {
+pub struct NewOrderParams {
     side: Side,
     order_type: OrderType,
     order_id: u128,
@@ -195,13 +195,13 @@ pub(crate) struct NewOrderParams {
     self_trade_behavior: SelfTradeBehavior,
 }
 
-struct OrderRemaining {
+pub struct OrderRemaining {
     coin_qty_remaining: NonZeroU64,
     native_pc_qty_remaining: Option<NonZeroU64>,
 }
 
 impl<'ob> OrderBookState<'ob> {
-    fn new_order(
+    pub fn new_order(
         &mut self,
 
         params: NewOrderParams,

--- a/dex/src/matching.rs
+++ b/dex/src/matching.rs
@@ -45,7 +45,7 @@ pub enum OrderType {
     PostOnly = 2,
 }
 
-fn extract_price_from_order_id(order_id: u128) -> u64 {
+pub fn extract_price_from_order_id(order_id: u128) -> u64 {
     (order_id >> 64) as u64
 }
 
@@ -57,14 +57,14 @@ pub struct OrderBookState<'a> {
 }
 
 impl<'ob> OrderBookState<'ob> {
-    fn orders_mut(&mut self, side: Side) -> &mut Slab {
+    pub fn orders_mut(&mut self, side: Side) -> &mut Slab {
         match side {
             Side::Bid => self.bids,
             Side::Ask => self.asks,
         }
     }
 
-    fn find_bbo(&self, side: Side) -> Option<NodeHandle> {
+    pub fn find_bbo(&self, side: Side) -> Option<NodeHandle> {
         match side {
             Side::Bid => self.bids.find_max(),
             Side::Ask => self.asks.find_min(),

--- a/dex/src/state.rs
+++ b/dex/src/state.rs
@@ -258,7 +258,7 @@ impl MarketState {
         Ok(open_orders)
     }
 
-    fn load_bids_mut<'a>(&self, bids: &'a AccountInfo) -> DexResult<RefMut<'a, Slab>> {
+    pub fn load_bids_mut<'a>(&self, bids: &'a AccountInfo) -> DexResult<RefMut<'a, Slab>> {
         check_assert_eq!(&bids.key.to_aligned_bytes(), &identity(self.bids))
             .map_err(|_| DexErrorCode::WrongBidsAccount)?;
         let (header, buf) = strip_header::<OrderBookStateHeader, u8>(bids, false)?;
@@ -267,7 +267,7 @@ impl MarketState {
         Ok(RefMut::map(buf, Slab::new))
     }
 
-    fn load_asks_mut<'a>(&self, asks: &'a AccountInfo) -> DexResult<RefMut<'a, Slab>> {
+    pub fn load_asks_mut<'a>(&self, asks: &'a AccountInfo) -> DexResult<RefMut<'a, Slab>> {
         check_assert_eq!(&asks.key.to_aligned_bytes(), &identity(self.asks))
             .map_err(|_| DexErrorCode::WrongAsksAccount)?;
         let (header, buf) = strip_header::<OrderBookStateHeader, u8>(asks, false)?;


### PR DESCRIPTION
# Overview

While attempting to get various bid/ask prices on-chain through CPI I ran into a few different issues due to various functions and enums not being marked as public. As far as I can tell the updated visibilities I have included in this repo are all that is needed to access this information on-chain through other programs.