### PR TITLE
Enable Loading Bids And Asks Via External Packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "serum_dex"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "arrayref",
  "bincode",

--- a/dex/src/state.rs
+++ b/dex/src/state.rs
@@ -258,7 +258,7 @@ impl MarketState {
         Ok(open_orders)
     }
 
-    fn load_bids_mut<'a>(&self, bids: &'a AccountInfo) -> DexResult<RefMut<'a, Slab>> {
+    pub fn load_bids_mut<'a>(&self, bids: &'a AccountInfo) -> DexResult<RefMut<'a, Slab>> {
         check_assert_eq!(&bids.key.to_aligned_bytes(), &identity(self.bids))
             .map_err(|_| DexErrorCode::WrongBidsAccount)?;
         let (header, buf) = strip_header::<OrderBookStateHeader, u8>(bids, false)?;
@@ -267,7 +267,7 @@ impl MarketState {
         Ok(RefMut::map(buf, Slab::new))
     }
 
-    fn load_asks_mut<'a>(&self, asks: &'a AccountInfo) -> DexResult<RefMut<'a, Slab>> {
+    pub fn load_asks_mut<'a>(&self, asks: &'a AccountInfo) -> DexResult<RefMut<'a, Slab>> {
         check_assert_eq!(&asks.key.to_aligned_bytes(), &identity(self.asks))
             .map_err(|_| DexErrorCode::WrongAsksAccount)?;
         let (header, buf) = strip_header::<OrderBookStateHeader, u8>(asks, false)?;


### PR DESCRIPTION
The functions in this PR when made public allow you to calculate orderbook pricing via external crates. This should address the concerns pointed out in https://github.com/project-serum/serum-dex/pull/106#issuecomment-825077598

edit:

When I attempted to build the codebase with `cargo build` after i made the change, `Cargo.lock` was updated automatically so I included it with the last commit. Let me know if I should remove this.