### PR TITLE
Export MarketState and Slab functions to read bid/ask data on-chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "serum_dex"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "arrayref",
  "bincode",

--- a/dex/Cargo.lock
+++ b/dex/Cargo.lock
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "serum_dex"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "arbitrary",
  "arrayref",

--- a/dex/src/critbit.rs
+++ b/dex/src/critbit.rs
@@ -28,7 +28,7 @@ enum NodeTag {
 #[derive(Copy, Clone)]
 #[repr(packed)]
 #[allow(dead_code)]
-struct InnerNode {
+pub struct InnerNode {
     tag: u32,
     prefix_len: u32,
     key: u128,
@@ -39,10 +39,14 @@ unsafe impl Zeroable for InnerNode {}
 unsafe impl Pod for InnerNode {}
 
 impl InnerNode {
-    fn walk_down(&self, search_key: u128) -> (NodeHandle, bool) {
+    pub fn walk_down(&self, search_key: u128) -> (NodeHandle, bool) {
         let crit_bit_mask = (1u128 << 127) >> self.prefix_len;
         let crit_bit = (search_key & crit_bit_mask) != 0;
         (self.children[crit_bit as usize], crit_bit)
+    }
+
+    pub fn prefix_len(&self) -> u32 {
+        self.prefix_len
     }
 }
 
@@ -168,18 +172,18 @@ pub struct AnyNode {
 unsafe impl Zeroable for AnyNode {}
 unsafe impl Pod for AnyNode {}
 
-enum NodeRef<'a> {
+pub enum NodeRef<'a> {
     Inner(&'a InnerNode),
     Leaf(&'a LeafNode),
 }
 
-enum NodeRefMut<'a> {
+pub enum NodeRefMut<'a> {
     Inner(&'a mut InnerNode),
     Leaf(&'a mut LeafNode),
 }
 
 impl AnyNode {
-    fn key(&self) -> Option<u128> {
+    pub fn key(&self) -> Option<u128> {
         match self.case()? {
             NodeRef::Inner(inner) => Some(inner.key),
             NodeRef::Leaf(leaf) => Some(leaf.key),
@@ -187,21 +191,21 @@ impl AnyNode {
     }
 
     #[cfg(test)]
-    fn prefix_len(&self) -> u32 {
+    pub fn prefix_len(&self) -> u32 {
         match self.case().unwrap() {
             NodeRef::Inner(&InnerNode { prefix_len, .. }) => prefix_len,
             NodeRef::Leaf(_) => 128,
         }
     }
 
-    fn children(&self) -> Option<[u32; 2]> {
+    pub fn children(&self) -> Option<[u32; 2]> {
         match self.case().unwrap() {
             NodeRef::Inner(&InnerNode { children, .. }) => Some(children),
             NodeRef::Leaf(_) => None,
         }
     }
 
-    fn case(&self) -> Option<NodeRef> {
+    pub fn case(&self) -> Option<NodeRef> {
         match NodeTag::try_from(self.tag) {
             Ok(NodeTag::InnerNode) => Some(NodeRef::Inner(cast_ref(self))),
             Ok(NodeTag::LeafNode) => Some(NodeRef::Leaf(cast_ref(self))),
@@ -209,7 +213,7 @@ impl AnyNode {
         }
     }
 
-    fn case_mut(&mut self) -> Option<NodeRefMut> {
+    pub fn case_mut(&mut self) -> Option<NodeRefMut> {
         match NodeTag::try_from(self.tag) {
             Ok(NodeTag::InnerNode) => Some(NodeRefMut::Inner(cast_mut(self))),
             Ok(NodeTag::LeafNode) => Some(NodeRefMut::Leaf(cast_mut(self))),
@@ -252,7 +256,7 @@ const_assert_eq!(_NODE_ALIGN, align_of::<AnyNode>());
 
 #[derive(Copy, Clone)]
 #[repr(packed)]
-struct SlabHeader {
+pub struct SlabHeader {
     bump_index: u64,
     free_list_len: u64,
     free_list_head: u32,
@@ -311,13 +315,13 @@ impl Slab {
         Ok(())
     }
 
-    fn check_size_align(&self) {
+    pub fn check_size_align(&self) {
         let (header_bytes, nodes_bytes) = array_refs![&self.0, SLAB_HEADER_LEN; .. ;];
         let _header: &SlabHeader = cast_ref(header_bytes);
         let _nodes: &[AnyNode] = cast_slice(nodes_bytes);
     }
 
-    fn parts(&self) -> (&SlabHeader, &[AnyNode]) {
+    pub fn parts(&self) -> (&SlabHeader, &[AnyNode]) {
         unsafe {
             invariant(self.0.len() < size_of::<SlabHeader>());
             invariant((self.0.as_ptr() as usize) % align_of::<SlabHeader>() != 0);
@@ -332,7 +336,7 @@ impl Slab {
         (header, nodes)
     }
 
-    fn parts_mut(&mut self) -> (&mut SlabHeader, &mut [AnyNode]) {
+    pub fn parts_mut(&mut self) -> (&mut SlabHeader, &mut [AnyNode]) {
         unsafe {
             invariant(self.0.len() < size_of::<SlabHeader>());
             invariant((self.0.as_ptr() as usize) % align_of::<SlabHeader>() != 0);
@@ -347,19 +351,19 @@ impl Slab {
         (header, nodes)
     }
 
-    fn header(&self) -> &SlabHeader {
+    pub fn header(&self) -> &SlabHeader {
         self.parts().0
     }
 
-    fn header_mut(&mut self) -> &mut SlabHeader {
+    pub fn header_mut(&mut self) -> &mut SlabHeader {
         self.parts_mut().0
     }
 
-    fn nodes(&self) -> &[AnyNode] {
+    pub fn nodes(&self) -> &[AnyNode] {
         self.parts().1
     }
 
-    fn nodes_mut(&mut self) -> &mut [AnyNode] {
+    pub fn nodes_mut(&mut self) -> &mut [AnyNode] {
         self.parts_mut().1
     }
 }
@@ -492,7 +496,7 @@ pub enum SlabTreeError {
 }
 
 impl Slab {
-    fn root(&self) -> Option<NodeHandle> {
+    pub fn root(&self) -> Option<NodeHandle> {
         if self.header().leaf_count == 0 {
             return None;
         }
@@ -600,7 +604,7 @@ impl Slab {
     }
 
     #[cfg(test)]
-    fn find_by_key(&self, search_key: u128) -> Option<NodeHandle> {
+    pub fn find_by_key(&self, search_key: u128) -> Option<NodeHandle> {
         let mut node_handle: NodeHandle = self.root()?;
         loop {
             let node_ref = self.get(node_handle).unwrap();
@@ -681,7 +685,7 @@ impl Slab {
     }
 
     #[cfg(test)]
-    fn traverse(&self) -> Vec<&LeafNode> {
+    pub fn traverse(&self) -> Vec<&LeafNode> {
         fn walk_rec<'a>(slab: &'a Slab, sub_root: NodeHandle, buf: &mut Vec<&'a LeafNode>) {
             match slab.get(sub_root).unwrap().case().unwrap() {
                 NodeRef::Leaf(leaf) => {

--- a/dex/src/state.rs
+++ b/dex/src/state.rs
@@ -259,7 +259,7 @@ impl MarketState {
         Ok(open_orders)
     }
 
-    fn load_bids_mut<'a>(&self, bids: &'a AccountInfo) -> DexResult<RefMut<'a, Slab>> {
+    pub fn load_bids_mut<'a>(&self, bids: &'a AccountInfo) -> DexResult<RefMut<'a, Slab>> {
         check_assert_eq!(&bids.key.to_aligned_bytes(), &identity(self.bids))
             .map_err(|_| DexErrorCode::WrongBidsAccount)?;
         let (header, buf) = strip_header::<OrderBookStateHeader, u8>(bids, false)?;
@@ -268,7 +268,7 @@ impl MarketState {
         Ok(RefMut::map(buf, Slab::new))
     }
 
-    fn load_asks_mut<'a>(&self, asks: &'a AccountInfo) -> DexResult<RefMut<'a, Slab>> {
+    pub fn load_asks_mut<'a>(&self, asks: &'a AccountInfo) -> DexResult<RefMut<'a, Slab>> {
         check_assert_eq!(&asks.key.to_aligned_bytes(), &identity(self.asks))
             .map_err(|_| DexErrorCode::WrongAsksAccount)?;
         let (header, buf) = strip_header::<OrderBookStateHeader, u8>(asks, false)?;
@@ -277,7 +277,7 @@ impl MarketState {
         Ok(RefMut::map(buf, Slab::new))
     }
 
-    fn load_request_queue_mut<'a>(&self, queue: &'a AccountInfo) -> DexResult<RequestQueue<'a>> {
+    pub fn load_request_queue_mut<'a>(&self, queue: &'a AccountInfo) -> DexResult<RequestQueue<'a>> {
         check_assert_eq!(&queue.key.to_aligned_bytes(), &identity(self.req_q))
             .map_err(|_| DexErrorCode::WrongRequestQueueAccount)?;
 
@@ -290,7 +290,7 @@ impl MarketState {
         Ok(Queue { header, buf })
     }
 
-    fn load_event_queue_mut<'a>(&self, queue: &'a AccountInfo) -> DexResult<EventQueue<'a>> {
+    pub fn load_event_queue_mut<'a>(&self, queue: &'a AccountInfo) -> DexResult<EventQueue<'a>> {
         check_assert_eq!(&queue.key.to_aligned_bytes(), &identity(self.event_q))
             .map_err(|_| DexErrorCode::WrongEventQueueAccount)?;
         let (header, buf) = strip_header::<EventQueueHeader, Event>(queue, false)?;


### PR DESCRIPTION
The `serum_dex` package has helper functions for reading bid/ask data from the slab tree, but some of them are not public. This PR makes these functions and associated structs and enums public. Not a breaking change.

Is it useful? Yes. We need these functions in production.

Edit: more functions from `critbit.rs` made public.