### PR TITLE
optimize settle_funds and accrue fee rebate at time of trade instead of event queue

### DIFF
--- a/dex/src/matching.rs
+++ b/dex/src/matching.rs
@@ -74,6 +74,7 @@ impl<'ob> OrderBookState<'ob> {
     pub(crate) fn process_orderbook_request(
         &mut self,
         request: &RequestView,
+        open_orders: &mut OpenOrders,
         event_q: &mut EventQueue,
         proceeds: &mut RequestProceeds,
         limit: &mut u16,
@@ -104,6 +105,7 @@ impl<'ob> OrderBookState<'ob> {
                         client_order_id: client_order_id.map_or(0, NonZeroU64::get),
                         self_trade_behavior,
                     },
+                    open_orders,
                     event_q,
                     proceeds,
                     limit,
@@ -205,6 +207,7 @@ impl<'ob> OrderBookState<'ob> {
         &mut self,
 
         params: NewOrderParams,
+        open_orders: &mut OpenOrders,
         event_q: &mut EventQueue,
 
         proceeds: &mut RequestProceeds,
@@ -251,6 +254,7 @@ impl<'ob> OrderBookState<'ob> {
                         client_order_id,
                         self_trade_behavior,
                     },
+                    open_orders,
                     event_q,
                     proceeds,
                 ),
@@ -269,6 +273,7 @@ impl<'ob> OrderBookState<'ob> {
                             client_order_id,
                             self_trade_behavior,
                         },
+                        open_orders,
                         event_q,
                         proceeds,
                     )
@@ -306,6 +311,7 @@ impl<'ob> OrderBookState<'ob> {
     fn new_ask(
         &mut self,
         params: NewAskParams,
+        open_orders: &mut OpenOrders,
         event_q: &mut EventQueue,
         to_release: &mut RequestProceeds,
     ) -> DexResult<Option<OrderRemaining>> {
@@ -507,6 +513,7 @@ impl<'ob> OrderBookState<'ob> {
         let referrer_rebate = fees::referrer_rebate(native_taker_fee);
         let net_fees = net_fees_before_referrer_rebate - referrer_rebate;
 
+        open_orders.referrer_rebates_accrued += referrer_rebate;
         self.market_state.referrer_rebates_accrued += referrer_rebate;
         self.market_state.pc_fees_accrued += net_fees;
         self.market_state.pc_deposits_total -= net_fees_before_referrer_rebate;
@@ -591,6 +598,7 @@ impl<'ob> OrderBookState<'ob> {
     fn new_bid(
         &mut self,
         params: NewBidParams,
+        open_orders: &mut OpenOrders,
         event_q: &mut EventQueue,
         to_release: &mut RequestProceeds,
     ) -> DexResult<Option<OrderRemaining>> {
@@ -825,6 +833,7 @@ impl<'ob> OrderBookState<'ob> {
         let referrer_rebate = fees::referrer_rebate(native_taker_fee);
         let net_fees = net_fees_before_referrer_rebate - referrer_rebate;
 
+        open_orders.referrer_rebates_accrued += referrer_rebate;
         self.market_state.referrer_rebates_accrued += referrer_rebate;
         self.market_state.pc_fees_accrued += net_fees;
         self.market_state.pc_deposits_total -= net_fees_before_referrer_rebate;

--- a/dex/src/state.rs
+++ b/dex/src/state.rs
@@ -2245,7 +2245,7 @@ impl State {
         } = args;
 
         let native_coin_amount = open_orders.native_coin_free;
-        let native_pc_amount = open_orders.native_pc_free;
+        let mut native_pc_amount = open_orders.native_pc_free;
 
         market.coin_deposits_total -= native_coin_amount;
         market.pc_deposits_total -= native_pc_amount;
@@ -2261,6 +2261,35 @@ impl State {
             .native_pc_total
             .checked_sub(native_pc_amount)
             .unwrap();
+
+        let nonce = market.vault_signer_nonce;
+        let market_pubkey = market.pubkey();
+        let vault_signer_seeds = gen_vault_signer_seeds(&nonce, &market_pubkey);
+
+        match referrer {
+            Some(referrer_pc_wallet) if open_orders.referrer_rebates_accrued > 0 => {
+                // If referrer is same as user, send_from_vault once
+                if referrer_pc_wallet.account().key == pc_wallet.account().key {
+                    native_pc_amount = native_pc_amount
+                        .checked_add(open_orders.referrer_rebates_accrued)
+                        .unwrap();
+                } else {
+                    send_from_vault(
+                        open_orders.referrer_rebates_accrued,
+                        referrer_pc_wallet.token_account(),
+                        pc_vault.token_account(),
+                        spl_token_program,
+                        vault_signer,
+                        &vault_signer_seeds,
+                    )?;
+                };
+            }
+            _ => {
+                market.pc_fees_accrued += open_orders.referrer_rebates_accrued;
+            }
+        };
+        market.referrer_rebates_accrued -= open_orders.referrer_rebates_accrued;
+        open_orders.referrer_rebates_accrued = 0;
 
         let token_infos: [(
             u64,
@@ -2279,10 +2308,6 @@ impl State {
             ),
         ];
 
-        let nonce = market.vault_signer_nonce;
-        let market_pubkey = market.pubkey();
-        let vault_signer_seeds = gen_vault_signer_seeds(&nonce, &market_pubkey);
-
         for &(token_amount, wallet_account, vault) in token_infos.iter() {
             send_from_vault(
                 token_amount,
@@ -2293,24 +2318,6 @@ impl State {
                 &vault_signer_seeds,
             )?;
         }
-
-        match referrer {
-            Some(referrer_pc_wallet) if open_orders.referrer_rebates_accrued > 0 => {
-                send_from_vault(
-                    open_orders.referrer_rebates_accrued,
-                    referrer_pc_wallet.token_account(),
-                    pc_vault.token_account(),
-                    spl_token_program,
-                    vault_signer,
-                    &vault_signer_seeds,
-                )?;
-            }
-            _ => {
-                market.pc_fees_accrued += open_orders.referrer_rebates_accrued;
-            }
-        };
-        market.referrer_rebates_accrued -= open_orders.referrer_rebates_accrued;
-        open_orders.referrer_rebates_accrued = 0;
 
         Ok(())
     }
@@ -2422,10 +2429,6 @@ impl State {
                         }
                         _ => (),
                     };
-                    if !maker {
-                        let referrer_rebate = fees::referrer_rebate(native_fee_or_rebate);
-                        open_orders.referrer_rebates_accrued += referrer_rebate;
-                    }
                     if let Some(client_id) = client_order_id {
                         debug_assert_eq!(
                             client_id.get(),
@@ -2601,6 +2604,7 @@ impl State {
         let mut limit = instruction.limit;
         let unfilled_portion = order_book_state.process_orderbook_request(
             &request,
+            open_orders,
             &mut event_q,
             &mut proceeds,
             &mut limit,


### PR DESCRIPTION
It saves something like 20k compute on settle funds by avoiding the extra CPI call. This has been working well on devnet for a month.