### PR TITLE
Dynamic sysvars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ _localnet: &localnet
     - 14
   before_script:
     - sudo apt-get install -y pkg-config build-essential libudev-dev
-    - sh -c "$(curl -sSfL https://release.solana.com/v1.6.9/install)"
+    - sh -c "$(curl -sSfL https://release.solana.com/v1.6.18/install)"
     - export PATH="/home/travis/.local/share/solana/install/active_release/bin:$PATH"
 
 jobs:

--- a/dex/Cargo.lock
+++ b/dex/Cargo.lock
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "serum_dex"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "arbitrary",
  "arrayref",

--- a/dex/Cargo.toml
+++ b/dex/Cargo.toml
@@ -18,7 +18,7 @@ default = ["program"]
 no-entrypoint = []
 
 [dependencies]
-solana-program = "1.5.5"
+solana-program = "1.6.18"
 spl-token = { version = "3.0.0-pre1", features = ["no-entrypoint"] }
 serde = "1.0.114"
 itertools = "0.9.0"

--- a/dex/crank/Cargo.toml
+++ b/dex/crank/Cargo.toml
@@ -13,8 +13,8 @@ serum-common = { path = "../../common", features = ["client"] }
 serum-context = { path = "../../context" }
 spl-token = { version = "3.0.0-pre1", features = ["no-entrypoint"], default-features = false }
 clap = "3.0.0-beta.1"
-solana-client = "1.4.4"
-solana-sdk = "1.4.4"
+solana-client = "1.6.18"
+solana-sdk = "1.6.18"
 anyhow = "1.0.32"
 rand = "0.7.3"
 safe-transmute = "0.11.0"

--- a/dex/src/state.rs
+++ b/dex/src/state.rs
@@ -1423,14 +1423,12 @@ pub(crate) mod account_parser {
                 array_refs![accounts, 5, 2, 2, 1];
 
             {
-                let rent = {
-                    // Dynamic sysvars don't work in unit tests.
-                    if cfg!(test) {
-                        Rent::from_account_info(&unchecked_rent[0])?
-                    } else {
-                        Rent::get()?
-                    }
-                };
+                // Dynamic sysvars don't work in unit tests.
+                #[cfg(test)]
+                let rent = Rent::from_account_info(&unchecked_rent[0])?;
+                #[cfg(not(test))]
+                let rent = Rent::get()?;
+
                 let (_, must_be_rent_exempt, _) = array_refs![accounts, 0; ..; 1];
                 for account in must_be_rent_exempt {
                     let data_len = account.data_len();
@@ -1643,14 +1641,13 @@ pub(crate) mod account_parser {
             };
 
             let mut market: RefMut<'a, MarketState> = MarketState::load(market_acc, program_id)?;
-            let rent = {
-                // Dynamic sysvars don't work in unit tests.
-                if cfg!(test) {
-                    Rent::from_account_info(rent_sysvar_acc)?
-                } else {
-                    Rent::get()?
-                }
-            };
+
+            // Dynamic sysvars don't work in unit tests.
+            #[cfg(test)]
+            let rent = Rent::from_account_info(rent_sysvar_acc)?;
+            #[cfg(not(test))]
+            let rent = Rent::get()?;
+
             let owner = SignerAccount::new(owner_acc)?;
             let fee_tier =
                 market.load_fee_tier(&owner.inner().key.to_aligned_bytes(), srm_or_msrm_account)?;

--- a/dex/src/state.rs
+++ b/dex/src/state.rs
@@ -15,12 +15,8 @@ use num_traits::FromPrimitive;
 use safe_transmute::{self, to_bytes::transmute_to_bytes, trivial::TriviallyTransmutable};
 
 use solana_program::{
-    account_info::AccountInfo,
-    program_error::ProgramError,
-    program_pack::Pack,
-    pubkey::Pubkey,
-    rent::Rent,
-    sysvar::{Sysvar, SysvarId},
+    account_info::AccountInfo, program_error::ProgramError, program_pack::Pack, pubkey::Pubkey,
+    rent::Rent, sysvar::Sysvar,
 };
 use spl_token::error::TokenError;
 
@@ -1318,11 +1314,6 @@ pub(crate) mod account_parser {
         }
     }
 
-    declare_validated_account_wrapper!(RentSysvarAccount, |account: &AccountInfo| {
-        check_assert!(Rent::check_id(account.key))?;
-        Ok(())
-    });
-
     declare_validated_account_wrapper!(SignerAccount, |account: &AccountInfo| {
         check_assert!(account.is_signer)?;
         Ok(())
@@ -1432,8 +1423,14 @@ pub(crate) mod account_parser {
                 array_refs![accounts, 5, 2, 2, 1];
 
             {
-                let rent_sysvar = RentSysvarAccount::new(&unchecked_rent[0])?;
-                let rent = Rent::from_account_info(rent_sysvar.inner()).or(check_unreachable!())?;
+                let rent = {
+                    // Dynamic sysvars don't work in unit tests.
+                    if cfg!(test) {
+                        Rent::from_account_info(&unchecked_rent[0])?
+                    } else {
+                        Rent::get()?
+                    }
+                };
                 let (_, must_be_rent_exempt, _) = array_refs![accounts, 0; ..; 1];
                 for account in must_be_rent_exempt {
                     let data_len = account.data_len();
@@ -1647,8 +1644,12 @@ pub(crate) mod account_parser {
 
             let mut market: RefMut<'a, MarketState> = MarketState::load(market_acc, program_id)?;
             let rent = {
-                let rent_sysvar = RentSysvarAccount::new(rent_sysvar_acc)?;
-                Rent::from_account_info(rent_sysvar.inner()).or(check_unreachable!())?
+                // Dynamic sysvars don't work in unit tests.
+                if cfg!(test) {
+                    Rent::from_account_info(rent_sysvar_acc)?
+                } else {
+                    Rent::get()?
+                }
             };
             let owner = SignerAccount::new(owner_acc)?;
             let fee_tier =
@@ -2064,14 +2065,11 @@ pub(crate) mod account_parser {
                 ref open_orders_acc,
                 ref owner_acc,
                 ref market_acc,
-                ref rent_acc,
+                ref _rent_acc,
             ] = array_ref![accounts, 0, 4];
 
             // Validate the accounts given are valid.
-            let rent = {
-                let rent_sysvar = RentSysvarAccount::new(rent_acc)?;
-                Rent::from_account_info(rent_sysvar.inner()).or(check_unreachable!())?
-            };
+            let rent = Rent::get()?;
             let owner = SignerAccount::new(owner_acc)?;
             let market = MarketState::load(market_acc, program_id)?;
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 ARG DEBIAN_FRONTEND=noninteractive
 
 ARG SOLANA_CHANNEL=v1.2.17
-ARG SOLANA_CLI=v1.6.9
+ARG SOLANA_CLI=v1.6.18
 
 ENV HOME="/root"
 ENV PATH="${HOME}/.cargo/bin:${PATH}"

--- a/scripts/travis/dex-tests.sh
+++ b/scripts/travis/dex-tests.sh
@@ -38,7 +38,7 @@ dex_whole_shebang() {
     #
     # Build the program.
     #
-    ./do.sh build dex
+    cd ./dex && cargo build-bpf && cd ../
     #
     # Deploy the program.
     #


### PR DESCRIPTION
Uses dynamic rent sysvars.

I've left the requirement to pass in the rent account to avoid breaking existing clients. However, due to the fact that clients dedup pubkeys when constructing the transaction, clients can now pass in dummy accounts instead of the rent sysvar to shrink the transaction size by one pubkey.