### PR TITLE
Optimize compute units with compiler flags

### DIFF
--- a/dex/Cargo.toml
+++ b/dex/Cargo.toml
@@ -47,7 +47,13 @@ proptest-derive = "0.2.0"
 bumpalo = { version = "3.4.0", features = ["collections"] }
 
 [profile.release]
-lto = true
+lto = "fat"
+codegen-units = 1
+
+[profile.release.build-override]
+opt-level = 3
+incremental = false
+codegen-units = 1
 
 [profile.test]
 opt-level = 2


### PR DESCRIPTION
Still need to profile, but this has been shown to significantly reduce compute unit consumption.