### PR TITLE
[WIP] Maker fill metadata

### DIFF
--- a/dex/Anchor.toml
+++ b/dex/Anchor.toml
@@ -1,0 +1,13 @@
+anchor_version = "0.12.0"
+
+[workspace]
+members = [
+    ".",
+]
+
+[provider]
+cluster = "localnet"
+wallet = "~/.config/solana/id.json"
+
+[programs.mainnet]
+serum_dex = { address = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin", path = "./target/deploy/serum_dex.so" }

--- a/dex/crank/src/lib.rs
+++ b/dex/crank/src/lib.rs
@@ -430,13 +430,15 @@ fn get_keys_for_market<'a>(
         if account_flags.intersects(AccountFlag::Permissioned) {
             let state = transmute_one_pedantic::<MarketStateV2>(transmute_to_bytes(&words))
                 .map_err(|e| e.without_src())?;
+            state.check_flags()?;
             state.inner
         } else {
-            transmute_one_pedantic::<MarketState>(transmute_to_bytes(&words))
-                .map_err(|e| e.without_src())?
+            let state = transmute_one_pedantic::<MarketState>(transmute_to_bytes(&words))
+                .map_err(|e| e.without_src())?;
+            state.check_flags()?;
+            state
         }
     };
-    market_state.check_flags()?;
     let vault_signer_key =
         gen_vault_signer_key(market_state.vault_signer_nonce, market, program_id)?;
     assert_eq!(

--- a/dex/src/instruction.rs
+++ b/dex/src/instruction.rs
@@ -987,7 +987,7 @@ pub fn prune(
         AccountMeta::new(*bids, false),
         AccountMeta::new(*asks, false),
         AccountMeta::new_readonly(*prune_authority, true),
-        AccountMeta::new_readonly(*open_orders, false),
+        AccountMeta::new(*open_orders, false),
         AccountMeta::new_readonly(*open_orders_owner, false),
         AccountMeta::new(*event_q, false),
     ];


### PR DESCRIPTION
- Add the taker's OOA public key to the maker fill event (based on a new AccountFlag)
- This makes it easier to do accounting for downstream protocols integrating with Serum that need to perform actions in response to trade events being processed