### PR TITLE
Remove gen_vault_signer_key for test

### DIFF
--- a/dex/src/state.rs
+++ b/dex/src/state.rs
@@ -1313,7 +1313,6 @@ fn gen_vault_signer_seeds<'a>(nonce: &'a u64, market: &'a Pubkey) -> [&'a [u8]; 
     [market.as_ref(), bytes_of(nonce)]
 }
 
-#[cfg(not(any(test, feature = "fuzz")))]
 #[inline]
 pub fn gen_vault_signer_key(
     nonce: u64,
@@ -1322,16 +1321,6 @@ pub fn gen_vault_signer_key(
 ) -> Result<Pubkey, ProgramError> {
     let seeds = gen_vault_signer_seeds(&nonce, market);
     Ok(Pubkey::create_program_address(&seeds, program_id)?)
-}
-
-#[cfg(any(test, feature = "fuzz"))]
-pub fn gen_vault_signer_key(
-    nonce: u64,
-    market: &Pubkey,
-    _program_id: &Pubkey,
-) -> Result<Pubkey, ProgramError> {
-    gen_vault_signer_seeds(&nonce, market);
-    Ok(Pubkey::default())
 }
 
 #[cfg(not(any(test, feature = "fuzz")))]


### PR DESCRIPTION
Is there any reason for default `Pubkey` in `gen_vault_signer_key`?

My use case:
I'm trying to process instructions in Rust code with real data from the network (1. accounts data received from validators, so they are real 2. `fuzz` is used because only this feature process `spl_token` instructions instead of cross program invocations). Because `gen_vault_signer_key` produce default `Pubkey` I have a problem with `SettleFunds` instruction, I need to pass vault signer as default `Pubkey` for successful validation from serum dex and at the same time need to pass correct vault signer with real `Pubkey` for successful validation from spl_token. Currently, I changed `owner` pubkey for vault addresses but looks like a real in the key returned by `gen_vault_signer_key`.