### PR TITLE
Allow for certain instructions when market is disabled

### DIFF
--- a/dex/src/state.rs
+++ b/dex/src/state.rs
@@ -89,10 +89,19 @@ impl<'a> DerefMut for Market<'a> {
 
 impl<'a> Market<'a> {
     #[inline]
-    pub fn load(market_account: &'a AccountInfo, program_id: &Pubkey) -> DexResult<Self> {
+    pub fn load(
+        market_account: &'a AccountInfo,
+        program_id: &Pubkey,
+        // Allow for the market flag to be set to AccountFlag::Disabled
+        allow_disabled: bool,
+    ) -> DexResult<Self> {
         let flags = Market::account_flags(&market_account.try_borrow_data()?)?;
         if flags.intersects(AccountFlag::Permissioned) {
-            Ok(Market::V2(MarketStateV2::load(market_account, program_id)?))
+            Ok(Market::V2(MarketStateV2::load(
+                market_account,
+                program_id,
+                allow_disabled,
+            )?))
         } else {
             Ok(Market::V1(MarketState::load(market_account, program_id)?))
         }
@@ -200,6 +209,7 @@ impl MarketStateV2 {
     pub fn load<'a>(
         market_account: &'a AccountInfo,
         program_id: &Pubkey,
+        allow_disabled: bool,
     ) -> DexResult<RefMut<'a, Self>> {
         check_assert_eq!(market_account.owner, program_id)?;
 
@@ -215,16 +225,19 @@ impl MarketStateV2 {
             ))
         });
 
-        state.check_flags()?;
+        state.check_flags(allow_disabled)?;
         Ok(state)
     }
 
     #[inline]
-    pub fn check_flags(&self) -> DexResult {
+    pub fn check_flags(&self, allow_disabled: bool) -> DexResult {
         let flags = BitFlags::from_bits(self.account_flags)
             .map_err(|_| DexErrorCode::InvalidMarketFlags)?;
-        let required_flags =
+        let mut required_flags =
             AccountFlag::Initialized | AccountFlag::Market | AccountFlag::Permissioned;
+        if allow_disabled {
+            required_flags = required_flags | AccountFlag::Disabled;
+        }
         if flags != required_flags {
             Err(DexErrorCode::InvalidMarketFlags)?
         }
@@ -1703,7 +1716,7 @@ pub(crate) mod account_parser {
                 _ => check_unreachable!()?,
             };
 
-            let mut market = Market::load(market_acc, program_id)?;
+            let mut market = Market::load(market_acc, program_id, false)?;
 
             let signer = SignerAccount::new(signer_acc)?;
             let fee_tier = market
@@ -1797,7 +1810,7 @@ pub(crate) mod account_parser {
                 _ => check_unreachable!()?,
             };
 
-            let mut market = Market::load(market_acc, program_id)?;
+            let mut market = Market::load(market_acc, program_id, false)?;
 
             // Dynamic sysvars don't work in unit tests.
             #[cfg(any(test, feature = "fuzz"))]
@@ -1880,7 +1893,7 @@ pub(crate) mod account_parser {
                 &[ref event_q_acc],
                 _unused
             ) = array_refs![accounts, 0; .. ; 1, 1, 2];
-            let market = Market::load(market_acc, program_id)?;
+            let market = Market::load(market_acc, program_id, true)?;
             let event_q = market.load_event_queue_mut(event_q_acc)?;
             let args = ConsumeEventsArgs {
                 limit,
@@ -1919,7 +1932,7 @@ pub(crate) mod account_parser {
                 ref event_q_acc,
             ] = array_ref![accounts, 0, 6];
 
-            let mut market = Market::load(market_acc, program_id).or(check_unreachable!())?;
+            let mut market = Market::load(market_acc, program_id, true).or(check_unreachable!())?;
 
             let open_orders_signer = SignerAccount::new(open_orders_signer_acc)?;
             let mut open_orders = market.load_orders_mut(
@@ -1982,7 +1995,7 @@ pub(crate) mod account_parser {
 
             let client_order_id = NonZeroU64::new(client_order_id).ok_or(assertion_error!())?;
 
-            let mut market = Market::load(market_acc, program_id).or(check_unreachable!())?;
+            let mut market = Market::load(market_acc, program_id, true).or(check_unreachable!())?;
 
             let open_orders_signer = SignerAccount::new(open_orders_signer_acc)?;
             let mut open_orders = market.load_orders_mut(
@@ -2048,7 +2061,7 @@ pub(crate) mod account_parser {
                 ref spl_token_program_acc,
             ], remaining_accounts) = array_refs![accounts, 9; ..;];
             let spl_token_program = SplTokenProgram::new(spl_token_program_acc)?;
-            let market = Market::load(market_acc, program_id)?;
+            let market = Market::load(market_acc, program_id, true)?;
             let owner = SignerAccount::new(owner_acc).or(check_unreachable!())?;
 
             let coin_vault =
@@ -2104,7 +2117,7 @@ pub(crate) mod account_parser {
         ) -> DexResult<T> {
             check_assert_eq!(accounts.len(), 2)?;
             let &[ref market_acc, ref signer_acc] = array_ref![accounts, 0, 2];
-            let mut market = Market::load(market_acc, program_id)?;
+            let mut market = Market::load(market_acc, program_id, false)?;
             let authorization = SigningDisableAuthority::new(signer_acc)?;
 
             let args = DisableMarketArgs {
@@ -2140,7 +2153,7 @@ pub(crate) mod account_parser {
                 ref spl_token_program
             ] = array_ref![accounts, 0, 6];
 
-            let market = Market::load(market_acc, program_id)?;
+            let market = Market::load(market_acc, program_id, false)?;
             let pc_vault = PcVault::from_account(pc_vault_acc, &market)?;
             let fee_receiver = PcWallet::from_account(pc_wallet_acc, &market)?;
             let vault_signer = VaultSigner::new(vault_signer_acc, &market, program_id)?;
@@ -2183,7 +2196,7 @@ pub(crate) mod account_parser {
 
             // Validate the accounts given are valid.
             let owner = SignerAccount::new(owner_acc)?;
-            let market = Market::load(market_acc, program_id)?;
+            let market = Market::load(market_acc, program_id, true)?;
             let mut open_orders = market.load_orders_mut(
                 open_orders_acc,
                 Some(owner.inner()),
@@ -2249,7 +2262,7 @@ pub(crate) mod account_parser {
 
             // Validate the accounts given are valid.
             let owner = SignerAccount::new(owner_acc)?;
-            let market = Market::load(market_acc, program_id)?;
+            let market = Market::load(market_acc, program_id, false)?;
 
             // Perform open orders initialization.
             let _open_orders = market.load_orders_mut(
@@ -2294,7 +2307,7 @@ pub(crate) mod account_parser {
             ] = array_ref![accounts, 0, 7];
 
             let _prune_authority = SignerAccount::new(prune_auth_acc)?;
-            let mut market = Market::load(market_acc, program_id)?;
+            let mut market = Market::load(market_acc, program_id, false)?;
             check_assert!(market.prune_authority() == Some(prune_auth_acc.key))?;
             let open_orders_address = open_orders_acc.key;
             let mut open_orders = market.load_orders_mut(

--- a/dex/src/tests.rs
+++ b/dex/src/tests.rs
@@ -328,7 +328,7 @@ fn test_new_order() {
     .into_bump_slice();
 
     {
-        let market = Market::load(&accounts.market, &dex_program_id).unwrap();
+        let market = Market::load(&accounts.market, &dex_program_id, false).unwrap();
         assert_eq!(identity(market.pc_fees_accrued), 0);
         assert_eq!(identity(market.pc_deposits_total), 520_000);
     }
@@ -336,7 +336,7 @@ fn test_new_order() {
     State::process(dex_program_id, instruction_accounts, &instruction_data).unwrap();
 
     {
-        let market = Market::load(&accounts.market, &dex_program_id).unwrap();
+        let market = Market::load(&accounts.market, &dex_program_id, false).unwrap();
         assert_eq!(identity(market.referrer_rebates_accrued), 176);
         assert_eq!(identity(market.pc_fees_accrued), 584);
         assert_eq!(
@@ -345,7 +345,7 @@ fn test_new_order() {
         );
     }
     {
-        let open_orders_buyer = Market::load(&accounts.market, &dex_program_id)
+        let open_orders_buyer = Market::load(&accounts.market, &dex_program_id, false)
             .unwrap()
             .load_orders_mut(&orders_account_buyer, None, &dex_program_id, None, None)
             .unwrap();
@@ -353,7 +353,7 @@ fn test_new_order() {
         assert_eq!(identity(open_orders_buyer.native_coin_total), 0);
         assert_eq!(identity(open_orders_buyer.native_pc_free), 20_000);
         assert_eq!(identity(open_orders_buyer.native_pc_total), 520_000);
-        let open_orders_seller = Market::load(&accounts.market, &dex_program_id)
+        let open_orders_seller = Market::load(&accounts.market, &dex_program_id, false)
             .unwrap()
             .load_orders_mut(&orders_account_seller, None, &dex_program_id, None, None)
             .unwrap();
@@ -379,7 +379,7 @@ fn test_new_order() {
     }
 
     {
-        let market = Market::load(&accounts.market, &dex_program_id).unwrap();
+        let market = Market::load(&accounts.market, &dex_program_id, false).unwrap();
         assert_eq!(identity(market.referrer_rebates_accrued), 176);
         assert_eq!(identity(market.pc_fees_accrued), 584);
         assert_eq!(
@@ -388,7 +388,7 @@ fn test_new_order() {
         );
     }
     {
-        let open_orders_buyer = Market::load(&accounts.market, &dex_program_id)
+        let open_orders_buyer = Market::load(&accounts.market, &dex_program_id, false)
             .unwrap()
             .load_orders_mut(&orders_account_buyer, None, &dex_program_id, None, None)
             .unwrap();
@@ -396,7 +396,7 @@ fn test_new_order() {
         assert_eq!(identity(open_orders_buyer.native_coin_total), 4_000);
         assert_eq!(identity(open_orders_buyer.native_pc_free), 20_120);
         assert_eq!(identity(open_orders_buyer.native_pc_total), 120_120);
-        let open_orders_seller = Market::load(&accounts.market, &dex_program_id)
+        let open_orders_seller = Market::load(&accounts.market, &dex_program_id, false)
             .unwrap()
             .load_orders_mut(&orders_account_seller, None, &dex_program_id, None, None)
             .unwrap();


### PR DESCRIPTION
Allow these instructions to be executed when a market is disabled:
- CloseOpenOrders
- SettleFunds
- CancelOrderByClientIdV2
- CancelOrderV2
- ConsumeEvents