### PR TITLE
Update testnet and devnet api endpoint. Original config is obsolete.

### DIFF
--- a/common/src/client/mod.rs
+++ b/common/src/client/mod.rs
@@ -56,8 +56,8 @@ impl std::fmt::Display for Cluster {
 impl Cluster {
     pub fn url(&self) -> &str {
         match self {
-            Cluster::Devnet => "https://devnet.solana.com",
-            Cluster::Testnet => "https://testnet.solana.com",
+            Cluster::Devnet => "https://api.devnet.solana.com",
+            Cluster::Testnet => "https://api.testnet.solana.com",
             Cluster::Mainnet => "https://api.mainnet-beta.solana.com",
             Cluster::VipMainnet => "https://vip-api.mainnet-beta.solana.com",
             Cluster::Localnet => "http://127.0.0.1:8899",


### PR DESCRIPTION
Current crank commands is not working for devnet/testnet. Updated the src.