### PR TITLE
Swap Academy for Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <h4>
     <a href="https://projectserum.com/">Website</a>
     <span> | </span>
-    <a href="https://serum-academy.com/en/">Academy</a>
+    <a href="https://discord.gg/HSeFXbqsUX">Discord</a>
     <span> | </span>
     <a href="https://github.com/project-serum/awesome-serum">Awesome</a>
     <span> | </span>


### PR DESCRIPTION
The Serum Academy domain has been offline since I've been involved with the project, this issue https://github.com/project-serum/anchor/issues/909 said there's a broken Discord link but I'm not sure what that's referencing.