### PR TITLE
Change consume_events_once visibility to pub

### DIFF
--- a/dex/crank/src/lib.rs
+++ b/dex/crank/src/lib.rs
@@ -705,7 +705,7 @@ fn consume_events_wrapper(
     };
 }
 
-fn consume_events_once(
+pub fn consume_events_once(
     client: &RpcClient,
     program_id: &Pubkey,
     payer: &Keypair,


### PR DESCRIPTION
I am helping write a sandboxed testing environment for Solana ([check it out here](https://github.com/foonetic/solarium)) that contains support for creating, deploying and testing Serum markets. I was wondering if it were possible to change the visibility of `consume_events_once` to be public, because as far as I am aware, there is no other way to consume events only once. 

In our framework, we tell the crank to consume events on a separate thread for a certain amount of time rather than providing it with a quantity of events to consume, which is not ideal. It would be a great benefit to us if we could make this public, and I'm not sure I see any reason not to. If there is a better way to tackle consuming just once, I am open to suggestions.