### PR TITLE
Fix: stable market tiers

### DIFF
--- a/dex/src/fees.rs
+++ b/dex/src/fees.rs
@@ -90,7 +90,7 @@ impl FeeTier {
     pub fn from_srm_and_msrm_balances(market: &Pubkey, srm_held: u64, msrm_held: u64) -> FeeTier {
         let one_srm = 1_000_000;
 
-        if market == &stable_markets::usdt_usdc::ID || market == &stable_markets::msol_sol::ID {
+        if market == &stable_markets::usdt_usdc::ID || market == &stable_markets::msol_sol::ID || market == &stable_markets::ust_usdc::ID || market == &stable_markets::ust_usdt::ID || market == &stable_markets::stsol_sol::ID {
             return FeeTier::Stable;
         }
 

--- a/dex/src/state.rs
+++ b/dex/src/state.rs
@@ -537,17 +537,16 @@ impl MarketState {
         expected_owner: &[u64; 4],
         srm_or_msrm_account: Option<account_parser::TokenAccount>,
     ) -> DexResult<FeeTier> {
+        let market_addr = self.pubkey();
         let srm_or_msrm_account = match srm_or_msrm_account {
             Some(a) => a,
-            None => return Ok(FeeTier::Base),
+            None => return Ok(FeeTier::from_srm_and_msrm_balances(&market_addr, 0, 0)),
         };
         let data = srm_or_msrm_account.inner().try_borrow_data()?;
 
         let mut aligned_data: [u64; 9] = Zeroable::zeroed();
         bytes_of_mut(&mut aligned_data).copy_from_slice(&data[..72]);
         let (mint, owner, &[balance]) = array_refs![&aligned_data, 4, 4, 1];
-
-        let market_addr = self.pubkey();
 
         check_assert_eq!(owner, expected_owner)?;
         if mint == &srm_token::ID.to_aligned_bytes() {


### PR DESCRIPTION
What is the cost of comparing all those pubkeys? Are we worried?

spl-token seems to use `sol_memcmp` to do it "cheap"
https://github.com/solana-labs/solana-program-library/blob/master/token/program/src/processor.rs#L872-L876