### PR TITLE
Bump slog-stdlog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -3327,9 +3327,9 @@ dependencies = [
 
 [[package]]
 name = "slog-stdlog"
-version = "4.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8228ab7302adbf4fcb37e66f3cda78003feb521e7fd9e3847ec117a7784d0f5a"
+checksum = "6706b2ace5bbae7291d3f8d2473e2bfab073ccd7d03670946197aec98471fa3e"
 dependencies = [
  "log",
  "slog",


### PR DESCRIPTION
solana-labs/solana is attempting to bump our `log` dependency. We have a downstream-projects build which checks compatibility with serum-dex, and it is failing due to your slot-stdlog dependency: https://buildkite.com/solana-labs/solana/builds/71098#16143790-55b9-4498-94b7-ce879e147438

Will you consider bumping it?