### PR TITLE
Fix build when program feature flag disabled

### DIFF
--- a/dex/src/state.rs
+++ b/dex/src/state.rs
@@ -3239,6 +3239,7 @@ impl State {
         Ok(())
     }
 
+    #[cfg(feature = "program")]
     fn process_replace_orders_by_client_ids(
         args: account_parser::ReplaceOrdersByClientIdsArgs,
     ) -> DexResult {


### PR DESCRIPTION
Issue:

Running cargo build --no-default-features current fails due to the process_replace_orders_by_client_ids function not being hidden behind the feature flag. 