### PR TITLE
adds fix to build errors

### DIFF
--- a/dex/Cargo.toml
+++ b/dex/Cargo.toml
@@ -16,7 +16,7 @@ default = ["program"]
 no-entrypoint = []
 
 [dependencies]
-solana-program = "1.6.18"
+solana-program = "1.11"
 spl-token = { version = "3.0.0-pre1", features = ["no-entrypoint"] }
 serde = "1.0.114"
 itertools = "0.9.0"


### PR DESCRIPTION
Upon building dex using the command `cargo build-bpf --manifest-path=./Cargo.toml --bpf-out-dir=dist`,  I get the error 
```
error[E0107]: this struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> src/lib.rs:375:20
    |
375 |     StdoutLock(io::StdoutLock<'a>),
    |                    ^^^^^^^^^^---- help: remove these generics
    |                    |
    |                    expected 0 lifetime arguments

error[E0107]: this struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> src/lib.rs:376:20
    |
376 |     StderrLock(io::StderrLock<'a>),
    |                    ^^^^^^^^^^---- help: remove these generics
    |                    |
    |                    expected 0 lifetime arguments

For more information about this error, try `rustc --explain E0107`.
error: could not compile `termcolor` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: build failed
```
This is fixed by bumping up the solana-program version from `1.6.18` to `1.11`