### PR TITLE
feat: add `send_take` to `instruction.rs` to facilitate CPI

### DIFF
--- a/dex/src/instruction.rs
+++ b/dex/src/instruction.rs
@@ -1038,6 +1038,63 @@ pub fn sweep_fees(
     })
 }
 
+pub fn send_take(
+    market: &Pubkey,
+    request_queue: &Pubkey,
+    event_queue: &Pubkey,
+    market_bids: &Pubkey,
+    market_asks: &Pubkey,
+    coin_wallet: &Pubkey,
+    pc_wallet: &Pubkey,
+    wallet_owner: &Pubkey,
+    coin_vault: &Pubkey,
+    pc_vault: &Pubkey,
+    spl_token_program_id: &Pubkey,
+    vault_signer: &Pubkey,
+    srm_account_referral: Option<&Pubkey>,
+    program_id: &Pubkey,
+    side: Side,
+    limit_price: NonZeroU64,
+    max_coin_qty: NonZeroU64,
+    max_native_pc_qty_including_fees: NonZeroU64,
+    min_coin_qty: u64,
+    min_native_pc_qty: u64,
+    limit: u16,
+) -> Result<Instruction, DexError> {
+    let data = MarketInstruction::SendTake(SendTakeInstruction {
+        side,
+        limit_price,
+        max_coin_qty,
+        max_native_pc_qty_including_fees,
+        min_coin_qty,
+        min_native_pc_qty,
+        limit,
+    })
+    .pack();
+    let mut accounts = vec![
+        AccountMeta::new(*market, false),
+        AccountMeta::new(*request_queue, false),
+        AccountMeta::new(*event_queue, false),
+        AccountMeta::new(*market_bids, false),
+        AccountMeta::new(*market_asks, false),
+        AccountMeta::new(*coin_wallet, false),
+        AccountMeta::new(*pc_wallet, false),
+        AccountMeta::new_readonly(*wallet_owner, true),
+        AccountMeta::new(*coin_vault, false),
+        AccountMeta::new(*pc_vault, false),
+        AccountMeta::new_readonly(*spl_token_program_id, false),
+        AccountMeta::new_readonly(*vault_signer, false),
+    ];
+    if let Some(key) = srm_account_referral {
+        accounts.push(AccountMeta::new_readonly(*key, false))
+    }
+    Ok(Instruction {
+        program_id: *program_id,
+        data,
+        accounts,
+    })
+}
+
 pub fn close_open_orders(
     program_id: &Pubkey,
     open_orders: &Pubkey,


### PR DESCRIPTION
Add `send_take` to `instruction.rs` to facilitate CPI on top of #251.